### PR TITLE
DRIF-10451: label renovate_runs with owning team and service name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
+./idea
 .env
 renovator

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fortnoxab/renovator/pkg/command"
 	localredis "github.com/fortnoxab/renovator/pkg/redis"
 	"github.com/fortnoxab/renovator/pkg/renovate"
+	"github.com/fortnoxab/renovator/pkg/repoowner"
 	"github.com/fortnoxab/renovator/pkg/webserver"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
@@ -20,10 +21,14 @@ import (
 var renovateRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Name: "renovate_runs",
 	Help: "Number of renovate runs",
-}, []string{"result", "repo"})
+}, []string{"result", "repo", "team", "name"})
 
 func init() {
 	prometheus.MustRegister(renovateRuns)
+}
+
+type ownerResolver interface {
+	Resolve(repo string) (team, name string)
 }
 
 type Agent struct {
@@ -31,6 +36,7 @@ type Agent struct {
 	RedisClient     redis.Cmdable
 	MaxProcessCount int
 	Webserver       *webserver.Webserver
+	OwnerResolver   ownerResolver
 }
 
 func NewAgentFromContext(cCtx *cli.Context) (*Agent, error) {
@@ -44,6 +50,7 @@ func NewAgentFromContext(cCtx *cli.Context) (*Agent, error) {
 		RedisClient:     rc,
 		MaxProcessCount: cCtx.Int("max-process-count"),
 		Webserver:       &webserver.Webserver{Port: cCtx.String("port"), EnableMetrics: true},
+		OwnerResolver:   repoowner.NewFromEnv(),
 	}, nil
 }
 
@@ -72,12 +79,13 @@ func (a *Agent) Run(ctx context.Context) {
 					logrus.Infof("running renovate on repo: %s", repo)
 					start := time.Now()
 					err := a.Renovator.RunRenovate(repo)
+					team, name := a.OwnerResolver.Resolve(repo)
 					if err != nil {
-						renovateRuns.WithLabelValues("error", repo).Inc()
+						renovateRuns.WithLabelValues("error", repo, team, name).Inc()
 						logrus.Errorf("error renovating repo: %s err: %s", repo, err)
 						continue
 					}
-					renovateRuns.WithLabelValues("ok", repo).Inc()
+					renovateRuns.WithLabelValues("ok", repo, team, name).Inc()
 					logrus.Infof("finished renovating repo: %s in %s", repo, time.Since(start))
 				}
 			}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -24,6 +24,7 @@ func TestRun(t *testing.T) {
 		Renovator:       renovate.NewRunner(commanderMock),
 		RedisClient:     redisMock,
 		MaxProcessCount: 2,
+		OwnerResolver:   fakeResolver{},
 	}
 
 	redisMockList := redisMockList{
@@ -59,6 +60,10 @@ func TestRun(t *testing.T) {
 
 	a.Run(ctx)
 }
+
+type fakeResolver struct{}
+
+func (fakeResolver) Resolve(string) (string, string) { return "", "" }
 
 type redisMockList struct {
 	lock sync.RWMutex

--- a/pkg/repoowner/repoowner.go
+++ b/pkg/repoowner/repoowner.go
@@ -1,0 +1,69 @@
+package repoowner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const Unknown = "unknown"
+
+// repoConfig is the subset of a repo's root config.json used for alert routing
+type repoConfig struct {
+	ServiceName string `json:"serviceName"`
+	Team        string `json:"team"`
+}
+
+// Resolver looks up owner metadata from renovate's on-disk repo clones
+type Resolver struct {
+	// BaseDir mirrors renovate's RENOVATE_BASE_DIR; clones live under BaseDir/repos
+	BaseDir string
+	// Platform mirrors renovate's RENOVATE_PLATFORM and is a path segment in the clone layout
+	Platform string
+}
+
+func NewFromEnv() *Resolver {
+	// Mirror renovate's baseDir resolution (lib/workers/global/initialize.ts):
+	// baseDir = RENOVATE_BASE_DIR, else (RENOVATE_TMPDIR || os tmp) + "/renovate".
+	baseDir := os.Getenv("RENOVATE_BASE_DIR")
+	if baseDir == "" {
+		tmp := os.Getenv("RENOVATE_TMPDIR")
+		if tmp == "" {
+			tmp = os.TempDir()
+		}
+		baseDir = filepath.Join(tmp, "renovate")
+	}
+	return &Resolver{
+		BaseDir:  baseDir,
+		Platform: os.Getenv("RENOVATE_PLATFORM"),
+	}
+}
+
+func (r *Resolver) Resolve(repo string) (team, name string) {
+	slug, _, _ := strings.Cut(repo, "?") // drop per-repo options such as "?loglevel=debug"
+	team, name = Unknown, slug
+
+	path := filepath.Join(r.BaseDir, "repos", r.Platform, filepath.FromSlash(slug), "config.json")
+	data, err := os.ReadFile(path) // #nosec G304 -- path built from trusted env + discovered repo slug
+	if err != nil {
+		logrus.Warnf("repoowner: cannot read %s, defaulting team=%q: %s", path, Unknown, err)
+		return team, name
+	}
+
+	var config repoConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		logrus.Warnf("repoowner: cannot parse %s, defaulting team=%q: %s", path, Unknown, err)
+		return team, name
+	}
+
+	if config.Team != "" {
+		team = config.Team
+	}
+	if config.ServiceName != "" {
+		name = config.ServiceName
+	}
+	return team, name
+}

--- a/pkg/repoowner/repoowner_test.go
+++ b/pkg/repoowner/repoowner_test.go
@@ -1,0 +1,53 @@
+package repoowner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeConfig(t *testing.T, baseDir, platform, repo, body string) {
+	t.Helper()
+	dir := filepath.Join(baseDir, "repos", platform, filepath.FromSlash(repo))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	base := t.TempDir()
+	platform := "bitbucket-server"
+	r := &Resolver{BaseDir: base, Platform: platform}
+
+	writeConfig(t, base, platform, "fnx/currencies", `{"serviceName":"currencies","team":"gonix"}`)
+	writeConfig(t, base, platform, "gl/no-team", `{"serviceName":"cache"}`)
+	writeConfig(t, base, platform, "gl/broken", `{not json`)
+
+	cases := []struct {
+		name       string
+		repo       string
+		wantTeam   string
+		wantSvcNam string
+	}{
+		{"full config", "fnx/currencies", "gonix", "currencies"},
+		{"strips options", "fnx/currencies?loglevel=debug", "gonix", "currencies"},
+		{"missing team falls back, keeps serviceName", "gl/no-team", Unknown, "cache"},
+		{"broken json falls back to slug", "gl/broken", Unknown, "gl/broken"},
+		{"missing file falls back to slug", "gl/does-not-exist", Unknown, "gl/does-not-exist"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			team, name := r.Resolve(tc.repo)
+			if team != tc.wantTeam {
+				t.Errorf("team = %q, want %q", team, tc.wantTeam)
+			}
+			if name != tc.wantSvcNam {
+				t.Errorf("name = %q, want %q", name, tc.wantSvcNam)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  ## What
  Add `team` and `name` labels to the `renovate_runs` counter, resolved per repo from that repo's root `config.json`.

  ## Why
  DRIF-10451: when a renovate run doesn't exit successfully we want to alert the *owning* team. The agent already counts failures (`renovate_runs{result="error"}`) but without team attribution, so every failure looked the same.

  ## How
  - New `pkg/repoowner`: reads `team` + `serviceName` from `${baseDir}/repos/${platform}/<repo>/config.json` — the checkout renovate already cloned locally, so no platform API call and no credentials.
  - baseDir/platform resolution mirrors renovate's own (`lib/workers/global/initialize.ts`): `RENOVATE_BASE_DIR`, else `(RENOVATE_TMPDIR || os tmp)/renovate`; clone layout `repos/<platform>/<repo>` per `lib/workers/global/index.ts`. So it tracks renovate
  with zero deployment config.
  - Resolution never fails: missing/malformed `config.json` → `team="unknown"`, `name=<repo slug>`, so metrics/alerting keep working.
  - Labels added on both ok/error paths. Cardinality unchanged in practice (team/name are functionally determined by repo).

  ## Downstream
  The infra repo synthesises `renovate_failed{team,name}` from this counter and alerts on it, routed by `team`. No behaviour change until that ships.
  

**_Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>_**