### PR TITLE
Build on go1.26 Jenkins agent as go1.23 pool is retired

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ properties(
 	]
 )
 
-node('go1.23') {
+node('go1.26') {
 	container('run'){
 		def tag = ''
 		stage('Checkout') {


### PR DESCRIPTION
 ## What
  Point the Jenkins pipeline at the `go1.26` build agent (was `go1.23`).

  ## Why
  The `go1.23` agent label was retired from the Jenkins pool, so `main` builds fail to schedule (`There are no nodes with the label 'go1.23'`) and never reach the image push stage. Available Go agents are now `go1.24/1.25/1.26`; `go1.26` matches
  what other Go repos use.

  ## How
  `node('go1.23')` to `node('go1.26')`. No app impact: go.mod stays `go 1.23.2` so runtime semantics are unchanged, and the binary is a static `CGO_ENABLED=0` build so the agent image is irrelevant. Tests pass on 1.26.