### PR TITLE
Remove the clone persistRepoData keeps once config.json is read

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -27,16 +27,11 @@ func init() {
 	prometheus.MustRegister(renovateRuns)
 }
 
-type ownerResolver interface {
-	Resolve(repo string) (team, name string)
-}
-
 type Agent struct {
 	Renovator       *renovate.Runner
 	RedisClient     redis.Cmdable
 	MaxProcessCount int
 	Webserver       *webserver.Webserver
-	OwnerResolver   ownerResolver
 }
 
 func NewAgentFromContext(cCtx *cli.Context) (*Agent, error) {
@@ -50,8 +45,25 @@ func NewAgentFromContext(cCtx *cli.Context) (*Agent, error) {
 		RedisClient:     rc,
 		MaxProcessCount: cCtx.Int("max-process-count"),
 		Webserver:       &webserver.Webserver{Port: cCtx.String("port"), EnableMetrics: true},
-		OwnerResolver:   repoowner.NewFromEnv(),
 	}, nil
+}
+
+// processRepo is its own func so the clone Cleanup can be deferred per repo.
+func (a *Agent) processRepo(repo string) {
+	logrus.Infof("running renovate on repo: %s", repo)
+	start := time.Now()
+
+	run, err := a.Renovator.RunRenovate(repo)
+	defer run.Cleanup()
+
+	team, name := repoowner.Resolve(run.CloneDir, run.Slug)
+	if err != nil {
+		renovateRuns.WithLabelValues("error", repo, team, name).Inc()
+		logrus.Errorf("error renovating repo: %s err: %s", repo, err)
+		return
+	}
+	renovateRuns.WithLabelValues("ok", repo, team, name).Inc()
+	logrus.Infof("finished renovating repo: %s in %s", repo, time.Since(start))
 }
 
 func (a *Agent) Run(ctx context.Context) {
@@ -76,17 +88,7 @@ func (a *Agent) Run(ctx context.Context) {
 				case <-ctx.Done():
 					return
 				case repo := <-reposToProcess:
-					logrus.Infof("running renovate on repo: %s", repo)
-					start := time.Now()
-					err := a.Renovator.RunRenovate(repo)
-					team, name := a.OwnerResolver.Resolve(repo)
-					if err != nil {
-						renovateRuns.WithLabelValues("error", repo, team, name).Inc()
-						logrus.Errorf("error renovating repo: %s err: %s", repo, err)
-						continue
-					}
-					renovateRuns.WithLabelValues("ok", repo, team, name).Inc()
-					logrus.Infof("finished renovating repo: %s in %s", repo, time.Since(start))
+					a.processRepo(repo)
 				}
 			}
 		}()

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -20,50 +22,52 @@ func TestRun(t *testing.T) {
 
 	commanderMock := mocks.NewMockCommander(t)
 	redisMock := mocks.NewMockCmdable(t)
+	runner := renovate.NewRunner(commanderMock)
+	runner.BaseDir = t.TempDir()
+	runner.Platform = "bitbucket-server"
 	a := &Agent{
-		Renovator:       renovate.NewRunner(commanderMock),
+		Renovator:       runner,
 		RedisClient:     redisMock,
 		MaxProcessCount: 2,
-		OwnerResolver:   fakeResolver{},
 	}
 
-	redisMockList := redisMockList{
-		list: []string{"project1/repo1", "project1/repo2", "project2/repo1"},
+	repos := []string{"project1/repo1", "project1/repo2", "project2/repo1"}
+	cloneDir := func(repo string) string {
+		return filepath.Join(runner.BaseDir, "repos", runner.Platform, filepath.FromSlash(repo))
 	}
+
+	redisMockList := redisMockList{list: repos}
 
 	redisMockCall := redisMock.On("BLPop", mock.Anything, time.Duration(time.Second*5), "renovator-joblist")
 	redisMockCall.RunFn = func(a mock.Arguments) {
 		redisMockCall.ReturnArguments = mock.Arguments{redisMockList.LPop()}
 	}
 
-	commanderMock.On("RunWithEnv", []string{}, "renovate", "project1/repo1").
-		Run(func(args mock.Arguments) {
-			time.Sleep(200 * time.Millisecond)
-		}).
-		Return(nil).
-		Once()
-	commanderMock.On("RunWithEnv", []string{}, "renovate", "project1/repo2").
-		Run(func(args mock.Arguments) {
-			time.Sleep(200 * time.Millisecond)
-		}).
-		Return(nil).
-		Once()
-	commanderMock.On("RunWithEnv", []string{}, "renovate", "project2/repo1").
-		Run(func(args mock.Arguments) {
-			time.Sleep(200 * time.Millisecond)
-		}).
-		Return(nil).
-		Once()
+	for _, repo := range repos {
+		dir := cloneDir(repo)
+		commanderMock.On("RunWithEnv", []string{}, "renovate", "--persist-repo-data=true", repo).
+			Run(func(mock.Arguments) {
+				if err := os.MkdirAll(dir, 0o750); err != nil { // renovate keeps the clone
+					t.Error(err)
+				}
+				time.Sleep(200 * time.Millisecond)
+			}).
+			Return(nil).
+			Once()
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
 	a.Run(ctx)
+
+	// The agent must remove the clones, or the disk fills up.
+	for _, repo := range repos {
+		if _, err := os.Stat(cloneDir(repo)); !os.IsNotExist(err) {
+			t.Errorf("clone %s was not removed", cloneDir(repo))
+		}
+	}
 }
-
-type fakeResolver struct{}
-
-func (fakeResolver) Resolve(string) (string, string) { return "", "" }
 
 type redisMockList struct {
 	lock sync.RWMutex

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -4,34 +4,74 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fortnoxab/renovator/pkg/command"
+	"github.com/sirupsen/logrus"
 )
 
 type Runner struct {
+	// BaseDir and Platform mirror renovate's, so we can find the repo clones it makes
+	BaseDir   string
+	Platform  string
 	commander command.Commander
 }
 
 func NewRunner(c command.Commander) *Runner {
 	return &Runner{
+		BaseDir:   baseDirFromEnv(),
+		Platform:  os.Getenv("RENOVATE_PLATFORM"),
 		commander: c,
 	}
 }
 
-func (r *Runner) RunRenovate(repo string) error {
-	repo, options, _ := strings.Cut(repo, "?")
+// baseDirFromEnv mirrors renovate's own resolution in lib/workers/global/initialize.ts.
+func baseDirFromEnv() string {
+	dir := os.Getenv("RENOVATE_BASE_DIR")
+	if dir == "" {
+		tmp := os.Getenv("RENOVATE_TMPDIR")
+		if tmp == "" {
+			tmp = os.TempDir()
+		}
+		dir = filepath.Join(tmp, "renovate")
+	}
+	return dir
+}
+
+// Run is a finished renovate run. Cleanup is never nil.
+type Run struct {
+	Slug     string
+	CloneDir string
+	Cleanup  func()
+}
+
+// RunRenovate keeps the clone via persistRepoData so the caller can read from CloneDir,
+// and hands back Cleanup to remove it again.
+func (r *Runner) RunRenovate(repo string) (Run, error) {
+	slug, options, _ := strings.Cut(repo, "?")
+
+	dir := filepath.Join(r.BaseDir, "repos", r.Platform, filepath.FromSlash(slug))
+	run := Run{
+		Slug:     slug,
+		CloneDir: dir,
+		Cleanup: func() {
+			if err := os.RemoveAll(dir); err != nil {
+				logrus.Warnf("error removing clone: %s, err: %s", dir, err)
+			}
+		},
+	}
 
 	env := []string{}
 	switch options {
 	case "loglevel=debug":
 		env = []string{"LOG_LEVEL=debug"}
 	}
-	err := r.commander.RunWithEnv(env, "renovate", repo)
+	err := r.commander.RunWithEnv(env, "renovate", "--persist-repo-data=true", slug)
 	if err != nil {
-		return fmt.Errorf("error running renovate on repo: %s, err: %w", repo, err)
+		return run, fmt.Errorf("error running renovate on repo: %s, err: %w", slug, err)
 	}
-	return nil
+	return run, nil
 }
 
 // DoAutoDiscover returns a list of repos

--- a/pkg/renovate/renovate_test.go
+++ b/pkg/renovate/renovate_test.go
@@ -1,0 +1,48 @@
+package renovate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fortnoxab/renovator/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRunRenovate(t *testing.T) {
+	base := t.TempDir()
+	commanderMock := mocks.NewMockCommander(t)
+	r := NewRunner(commanderMock)
+	r.BaseDir = base
+	r.Platform = "bitbucket-server"
+
+	dir := filepath.Join(base, "repos", "bitbucket-server", "fo", "wzrd")
+	commanderMock.On("RunWithEnv", []string{"LOG_LEVEL=debug"}, "renovate", "--persist-repo-data=true", "fo/wzrd").
+		Run(func(mock.Arguments) {
+			if err := os.MkdirAll(dir, 0o750); err != nil {
+				t.Error(err)
+			}
+		}).
+		Return(nil).
+		Once()
+
+	run, err := r.RunRenovate("fo/wzrd?loglevel=debug")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Slug != "fo/wzrd" {
+		t.Errorf("slug = %q, want %q", run.Slug, "fo/wzrd")
+	}
+	if run.CloneDir != dir {
+		t.Errorf("cloneDir = %q, want %q", run.CloneDir, dir)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("clone should exist before cleanup: %s", err)
+	}
+
+	run.Cleanup()
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("clone %s was not removed", dir)
+	}
+}

--- a/pkg/repoowner/repoowner.go
+++ b/pkg/repoowner/repoowner.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -17,36 +16,11 @@ type repoConfig struct {
 	Team        string `json:"team"`
 }
 
-// Resolver looks up owner metadata from renovate's on-disk repo clones
-type Resolver struct {
-	// BaseDir mirrors renovate's RENOVATE_BASE_DIR; clones live under BaseDir/repos
-	BaseDir string
-	// Platform mirrors renovate's RENOVATE_PLATFORM and is a path segment in the clone layout
-	Platform string
-}
-
-func NewFromEnv() *Resolver {
-	// Mirror renovate's baseDir resolution (lib/workers/global/initialize.ts):
-	// baseDir = RENOVATE_BASE_DIR, else (RENOVATE_TMPDIR || os tmp) + "/renovate".
-	baseDir := os.Getenv("RENOVATE_BASE_DIR")
-	if baseDir == "" {
-		tmp := os.Getenv("RENOVATE_TMPDIR")
-		if tmp == "" {
-			tmp = os.TempDir()
-		}
-		baseDir = filepath.Join(tmp, "renovate")
-	}
-	return &Resolver{
-		BaseDir:  baseDir,
-		Platform: os.Getenv("RENOVATE_PLATFORM"),
-	}
-}
-
-func (r *Resolver) Resolve(repo string) (team, name string) {
-	slug, _, _ := strings.Cut(repo, "?") // drop per-repo options such as "?loglevel=debug"
+// Resolve reads the owning team and service name from a repo clone's config.json.
+func Resolve(cloneDir, slug string) (team, name string) {
 	team, name = Unknown, slug
 
-	path := filepath.Join(r.BaseDir, "repos", r.Platform, filepath.FromSlash(slug), "config.json")
+	path := filepath.Join(cloneDir, "config.json")
 	data, err := os.ReadFile(path) // #nosec G304 -- path built from trusted env + discovered repo slug
 	if err != nil {
 		logrus.Warnf("repoowner: cannot read %s, defaulting team=%q: %s", path, Unknown, err)

--- a/pkg/repoowner/repoowner_test.go
+++ b/pkg/repoowner/repoowner_test.go
@@ -6,42 +6,52 @@ import (
 	"testing"
 )
 
-func writeConfig(t *testing.T, baseDir, platform, repo, body string) {
+func writeConfig(t *testing.T, dir, body string) string {
 	t.Helper()
-	dir := filepath.Join(baseDir, "repos", platform, filepath.FromSlash(repo))
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	return dir
 }
 
 func TestResolve(t *testing.T) {
 	base := t.TempDir()
-	platform := "bitbucket-server"
-	r := &Resolver{BaseDir: base, Platform: platform}
-
-	writeConfig(t, base, platform, "fnx/currencies", `{"serviceName":"currencies","team":"gonix"}`)
-	writeConfig(t, base, platform, "gl/no-team", `{"serviceName":"cache"}`)
-	writeConfig(t, base, platform, "gl/broken", `{not json`)
 
 	cases := []struct {
 		name       string
-		repo       string
+		cloneDir   string
+		slug       string
 		wantTeam   string
 		wantSvcNam string
 	}{
-		{"full config", "fnx/currencies", "gonix", "currencies"},
-		{"strips options", "fnx/currencies?loglevel=debug", "gonix", "currencies"},
-		{"missing team falls back, keeps serviceName", "gl/no-team", Unknown, "cache"},
-		{"broken json falls back to slug", "gl/broken", Unknown, "gl/broken"},
-		{"missing file falls back to slug", "gl/does-not-exist", Unknown, "gl/does-not-exist"},
+		{
+			"full config",
+			writeConfig(t, filepath.Join(base, "currencies"), `{"serviceName":"currencies","team":"gonix"}`),
+			"fnx/currencies", "gonix", "currencies",
+		},
+		{
+			"missing team falls back, keeps serviceName",
+			writeConfig(t, filepath.Join(base, "no-team"), `{"serviceName":"cache"}`),
+			"gl/no-team", Unknown, "cache",
+		},
+		{
+			"broken json falls back to slug",
+			writeConfig(t, filepath.Join(base, "broken"), `{not json`),
+			"gl/broken", Unknown, "gl/broken",
+		},
+		{
+			"missing clone falls back to slug",
+			filepath.Join(base, "does-not-exist"),
+			"gl/does-not-exist", Unknown, "gl/does-not-exist",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			team, name := r.Resolve(tc.repo)
+			team, name := Resolve(tc.cloneDir, tc.slug)
 			if team != tc.wantTeam {
 				t.Errorf("team = %q, want %q", team, tc.wantTeam)
 			}


### PR DESCRIPTION
 ## What
  Keep renovate's repo clone long enough to read the repo's `config.json`, then remove it.

  ## Why
  A repo's owning team and service name live in its root `config.json`, which only exists inside the clone renovate  makes. Renovate deletes that clone as soon as it finishes with a repo, so the file is gone by the time `RunRenovate` returns. `--persist-repo-data=true` keeps it, which makes removing it renovator's job.

  ## How
  - `RunRenovate` passes `--persist-repo-data=true` and returns a `Run` with `Slug`, `CloneDir` and a `Cleanup` func, so the package that keeps the clone also owns removing it.
  - The agent defers `run.Cleanup()`. It sits in a `processRepo` func because a `defer` in the worker loop would only fire when the goroutine exits, not per repo.
  - `Cleanup` is set before the command runs and is never nil, so the defer is safe on the error path too.
  - `repoowner.Resolve(cloneDir, slug)` reads the file, falling back to team `unknown` and name = repo slug