### PR TITLE
Quiet the missing config.json log and add team to the finish line

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -63,7 +63,7 @@ func (a *Agent) processRepo(repo string) {
 		return
 	}
 	renovateRuns.WithLabelValues("ok", repo, team, name).Inc()
-	logrus.Infof("finished renovating repo: %s in %s", repo, time.Since(start))
+	logrus.Infof("finished renovating repo: %s (team %s) in %s", repo, team, time.Since(start))
 }
 
 func (a *Agent) Run(ctx context.Context) {

--- a/pkg/repoowner/repoowner.go
+++ b/pkg/repoowner/repoowner.go
@@ -23,7 +23,8 @@ func Resolve(cloneDir, slug string) (team, name string) {
 	path := filepath.Join(cloneDir, "config.json")
 	data, err := os.ReadFile(path) // #nosec G304 -- path built from trusted env + discovered repo slug
 	if err != nil {
-		logrus.Warnf("repoowner: cannot read %s, defaulting team=%q: %s", path, Unknown, err)
+		// Plenty of repos have no config.json, so this is expected rather than a problem.
+		logrus.Debugf("repoowner: cannot read %s, defaulting team=%q: %s", path, Unknown, err)
 		return team, name
 	}
 


### PR DESCRIPTION
  ## What
  Log a missing `config.json` at debug instead of warn, and include the resolved team in the finished-renovating line.

  ## Why
  A third of the repos we process have no `config.json`, which is expected rather than a problem, and it was producing roughly 4,600 warn lines a day. Which repos lack an owner is better answered from the metric anyway:

  ```promql
  count by (repo) (renovate_runs{team="unknown"})

  A malformed config.json still logs at warn, since that one is actionable.

  Nothing logged the resolved team on success, so confirming attribution meant leaving the logs for Grafana. 
  Having it on the finish line makes it checkable in one place.
  ``` 
  How

  - repoowner.Resolve: Warnf to Debugf on the read error only.
  - agent.processRepo: finished renovating repo: %s (team %s) in %s.